### PR TITLE
Re-use existing task definition; ability to provide container overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Usage
                                           the awsvpc network mode to receive their own elastic network interface, and it is not supported
                                           for other network modes. (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
         --copy-task-definition-tags   Copy the existing task definition tags to the new task definition revision
+        --create-new-task-definition  Create a new task defintion, based on the active task definition, for deployment (default: false).
+        --env                         Container environment overrides, only applicable for run-task, currently limited to one set per container.
+                                          Three values expected as comma delimited string: --env <container_name>,<var_name>,<var_value>
+                                          (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
         -v | --verbose                Verbose output
              --version                Display the version
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -521,7 +521,7 @@ function updateService() {
 
 function waitForGreenDeployment {
   DEPLOYMENT_SUCCESS="false"
-  every=2
+  every=5
   i=0
   echo "Waiting for service deployment to complete..."
   while [ $i -lt $TIMEOUT ]
@@ -531,13 +531,14 @@ function waitForGreenDeployment {
     # Wait to see if more than 1 deployment stays running
     # If the wait time has passed, we need to roll back
     if [ $NUM_DEPLOYMENTS -eq 1 ]; then
-      echo "Service deployment successful."
+      printf "\nService deployment successful.\n"
       DEPLOYMENT_SUCCESS="true"
       # Exit the loop.
       i=$TIMEOUT
     else
       sleep $every
       i=$(( $i + $every ))
+      printf "."
     fi
   done
 

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -80,7 +80,7 @@ Optional arguments:
                                        the awsvpc network mode to receive their own elastic network interface, and it is not supported
                                        for other network modes. (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
     --copy-task-definition-tags  Copy the existing task definition tags to the new task definition revision
-    --create-new-task-definition Create a new task defintion based on the active task definition to deploy.
+    --create-new-task-definition Create a new task defintion, based on the active task definition, for deployment (default: false).
     --env                        Container environment overrides, only applicable for run-task, currently limited to one set per container.
                                        Three values expected as comma delimited string: --env <container_name>,<var_name>,<var_value>
                                        (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -28,6 +28,9 @@ RUN_TASK_NETWORK_CONFIGURATION=false
 RUN_TASK_WAIT_FOR_SUCCESS=false
 TASK_DEFINITION_TAGS=false
 COPY_TASK_DEFINITION_TAGS=false
+CREATE_NEW_TASK_DEFINITION=false
+RUN_TASK_ENV_OVERRIDES_ARRAY=()
+OVERRIDE_JSON=""
 
 function usage() {
     cat <<EOM
@@ -77,6 +80,10 @@ Optional arguments:
                                        the awsvpc network mode to receive their own elastic network interface, and it is not supported
                                        for other network modes. (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
     --copy-task-definition-tags  Copy the existing task definition tags to the new task definition revision
+    --create-new-task-definition Create a new task defintion based on the active task definition to deploy.
+    --env                        Container environment overrides, only applicable for run-task, currently limited to one set per container.
+                                       Three values expected as comma delimited string: --env <container_name>,<var_name>,<var_value>
+                                       (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
     -v | --verbose               Verbose output
          --version               Display the version
 
@@ -172,7 +179,7 @@ function assertRequiredArgumentsSet() {
         echo "CLUSTER is required. You can pass the value using -c or --cluster"
         exit 7
     fi
-    if [ $IMAGE == false ] && [ $FORCE_NEW_DEPLOYMENT == false ]; then
+    if [ $IMAGE == false ] && [ $RUN_TASK == false ] && [ $FORCE_NEW_DEPLOYMENT == false ]; then
         echo "IMAGE is required. You can pass the value using -i or --image"
         exit 8
     fi
@@ -542,6 +549,18 @@ function waitForGreenDeployment {
   fi
 }
 
+function generateContainerOverrideJSON {
+    for containerEnvVar in ${RUN_TASK_ENV_OVERRIDES_ARRAY[@]+"${RUN_TASK_ENV_OVERRIDES_ARRAY[@]}"}; do
+      if [ -n "$OVERRIDE_JSON" ]; then
+        OVERRIDE_JSON+=','    
+      fi
+      arr=(`echo $containerEnvVar | sed 's/,/\n/g'`)
+      OVERRIDE_JSON+='{"name": "'${arr[0]}'","environment": [{"name": "'${arr[1]}'","value": "'${arr[2]}'"}]}'
+    done
+    OVERRIDE_JSON='{"containerOverrides": ['$OVERRIDE_JSON']}'
+    # echo "Debug OVERRIDE_JSON: $OVERRIDE_JSON"
+}
+
 function runTask {
   echo "Run task: $NEW_TASKDEF";
   AWS_ECS_RUN_TASK="$AWS_ECS run-task --cluster $CLUSTER --task-definition $NEW_TASKDEF"
@@ -557,6 +576,11 @@ function runTask {
     AWS_ECS_RUN_TASK="$AWS_ECS_RUN_TASK --network-configuration \"$RUN_TASK_NETWORK_CONFIGURATION\""
   fi
 
+  if [ -n "$OVERRIDE_JSON" ]; then  
+    AWS_ECS_RUN_TASK="$AWS_ECS_RUN_TASK --overrides '$OVERRIDE_JSON'"
+  fi
+
+  echo "ECS run-task command: $AWS_ECS_RUN_TASK"
   TASK_ARN=$(eval $AWS_ECS_RUN_TASK | jq -r '.tasks[0].taskArn')
   echo "Executed task: $TASK_ARN"
 
@@ -728,6 +752,13 @@ if [ "$BASH_SOURCE" == "$0" ]; then
             --copy-task-definition-tags)
                 COPY_TASK_DEFINITION_TAGS=true
                 ;;
+            --create-new-task-definition)
+                CREATE_NEW_TASK_DEFINITION=true
+                ;;
+            --env)
+                RUN_TASK_ENV_OVERRIDES_ARRAY+=( "$2" )
+                shift
+                ;;
             -v|--verbose)
                 VERBOSE=true
                 ;;
@@ -767,19 +798,29 @@ if [ "$BASH_SOURCE" == "$0" ]; then
     fi
 
     # Determine image name
-    parseImageName
-    echo "Using image name: $useImage"
+    if [ $IMAGE != false ]; then
+        parseImageName
+        echo "Using image name: $useImage"
+    fi
 
     # Get current task definition
     getCurrentTaskDefinition
     echo "Current task definition: $TASK_DEFINITION_ARN";
 
-    # create new task definition json
-    createNewTaskDefJson
+    # generate container (environment variable) override JSON
+    generateContainerOverrideJSON
 
-    # register new task definition
-    registerNewTaskDefinition
-    echo "New task definition: $NEW_TASKDEF";
+    if [ $CREATE_NEW_TASK_DEFINITION == false ]; then
+        NEW_TASKDEF=$TASK_DEFINITION_ARN
+        echo "Re-using current task definition: $NEW_TASKDEF";
+    else
+        # create new task definition json
+        createNewTaskDefJson
+
+        # register new task definition
+        registerNewTaskDefinition
+        echo "New task definition: $NEW_TASKDEF";
+    fi
 
     # update service if needed
     if [ $SERVICE == false ]; then


### PR DESCRIPTION
Re-use existing task definition by default; ability to provide container overrides, specifically environment variables:
- re-use existing task definition behavior can be altered with the '--CREATE_NEW_TASK_DEFINITION' option
- container environment variable overrides are provided via the '--env' option